### PR TITLE
[Feat] 숙소 검색, 숙소 상세 조회 API 생성

### DIFF
--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/controller/AccommodationController.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/controller/AccommodationController.java
@@ -1,0 +1,33 @@
+package com.efub.agodaclone.accomodation.controller;
+
+import com.efub.agodaclone.accomodation.dto.request.AccommodationSearchRequestDto;
+import com.efub.agodaclone.accomodation.dto.response.AccommodationDetailResponseDto;
+import com.efub.agodaclone.accomodation.dto.response.AccommodationSearchListResponseDto;
+import com.efub.agodaclone.accomodation.service.AccommodationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/accommodations")
+@RequiredArgsConstructor
+public class AccommodationController {
+
+    private final AccommodationService accommodationService;
+
+    // 숙소 리스트 조회
+    @GetMapping
+    public ResponseEntity<AccommodationSearchListResponseDto> searchAccommodation(@RequestBody @Valid AccommodationSearchRequestDto requestDto){
+        AccommodationSearchListResponseDto responseDto = accommodationService.getAccommodationList(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 숙소 상세 조회
+    @GetMapping("/{accommodationId}")
+    public ResponseEntity<AccommodationDetailResponseDto> getAccommodationDetail(@PathVariable("accommodationId") Long accommodationId){
+        AccommodationDetailResponseDto responseDto = accommodationService.getDetailedAccommodation(accommodationId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/request/AccommodationSearchRequestDto.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/request/AccommodationSearchRequestDto.java
@@ -1,0 +1,24 @@
+package com.efub.agodaclone.accomodation.dto.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccommodationSearchRequestDto {
+
+    @NotBlank(message = "검색어를 입력해주세요.")
+    private String query;
+
+    @FutureOrPresent(message = "시작일은 오늘 이후여야 합니다.")
+    private LocalDate startDate;
+
+    @Future(message = "숙소 종료일은 시작일 다음날 이후로 선택해 주세요.")
+    private LocalDate endDate;
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/response/AccommodationDetailResponseDto.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/response/AccommodationDetailResponseDto.java
@@ -1,0 +1,59 @@
+package com.efub.agodaclone.accomodation.dto.response;
+
+
+import com.efub.agodaclone.accomodation.domain.Accommodation;
+import com.efub.agodaclone.accomodation.domain.AccommodationImage;
+import com.efub.agodaclone.room.domain.Room;
+import com.efub.agodaclone.room.domain.RoomImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter @Builder
+public class AccommodationDetailResponseDto {
+
+    private String korName;
+    private String engName;
+    private double totalScore;
+    private int reviewCount;
+    private String description;
+    private List<String> accommodationImgList;
+    private String roomType;
+    private String bed;
+    private List<String> roomImage;
+    private int price;
+//    private List<String> provisionTagList;
+    private double cleanlinessScore;
+    private double serviceScore;
+    private double locationScore;
+
+    public static AccommodationDetailResponseDto from(Accommodation accommodation, Room room, int discountPrice) {
+        return AccommodationDetailResponseDto.builder()
+                .korName(accommodation.getKorName())
+                .engName(accommodation.getEngName())
+                .totalScore(accommodation.getTotalScore())
+//                .reviewCount(accommodation.getReviewList.size())
+                .description(accommodation.getDescription())
+                .accommodationImgList(accommodation.getAccommodationImageList().stream()
+                                .map(AccommodationImage::getImgUrl)
+                                .collect(Collectors.toList())
+                )
+                .roomType(room.getRoomType())
+                .bed(room.getBed())
+                .roomImage(room.getRoomImageList().stream()
+                        .map(RoomImage::getImgUrl)
+                        .collect(Collectors.toList()))
+                .price(discountPrice)
+//                .provisionTag(accommodation.getProvisionTags().stream()
+//                        .map(ProvisionTag::getName)
+//                        .collect(Collectors.toList())
+//                )
+                .cleanlinessScore(accommodation.getCleanlinessScore())
+                .serviceScore(accommodation.getServiceScore())
+                .locationScore(accommodation.getLocationScore())
+                .build();
+    }
+
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/response/AccommodationSearchListResponseDto.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/response/AccommodationSearchListResponseDto.java
@@ -1,0 +1,35 @@
+package com.efub.agodaclone.accomodation.dto.response;
+
+import com.efub.agodaclone.accomodation.domain.Accommodation;
+import com.efub.agodaclone.accomodation.dto.summary.AccommodationSummary;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+@Builder @Getter
+public class AccommodationSearchListResponseDto {
+
+    private List<AccommodationSummary> accommodations;
+    private int currentPage;
+    private int totalPage;
+    private int totalCount;
+
+    public static AccommodationSearchListResponseDto from(List<Accommodation> accommodationList, int days, BiFunction<Integer, Integer, Integer> discountCalculator) {
+        List<AccommodationSummary> summaries = accommodationList.stream()
+                .map(accomodation -> {
+                    int discountPrice = discountCalculator.apply(accomodation.getPrice(), accomodation.getDiscountRate());
+                    return AccommodationSummary.from(accomodation, discountPrice, days);
+                })
+                .collect(Collectors.toList());
+
+        return AccommodationSearchListResponseDto.builder()
+                .accommodations(summaries)
+                .currentPage(1)
+                .totalPage(1)
+                .totalCount(summaries.size())
+                .build();
+    }
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/summary/AccommodationSummary.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/dto/summary/AccommodationSummary.java
@@ -1,0 +1,58 @@
+package com.efub.agodaclone.accomodation.dto.summary;
+
+import com.efub.agodaclone.accomodation.domain.Accommodation;
+import com.efub.agodaclone.room.domain.Room;
+import com.efub.agodaclone.room.domain.RoomImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter @Builder
+public class AccommodationSummary {
+
+    private String korName;
+    private String engName;
+    private double totalScore;
+    private int reviewCount;
+    private String description;
+    //    private List<String> provisionTagList;
+
+    private String roomType;
+    private String bed;
+    private List<String> roomImages;
+
+    private int discountPrice;
+    private int totalPrice;
+
+    private double cleanlinessScore;
+    private double serviceScore;
+    private double locationScore;
+
+    public static AccommodationSummary from(Accommodation accommodation, int discountPrice, int days) {
+        Room room = accommodation.getRoomList().get(0); // 객실 1개만 사용
+        return AccommodationSummary.builder()
+                .korName(accommodation.getKorName())
+                .engName(accommodation.getEngName())
+                .totalScore(accommodation.getTotalScore())
+//                .reviewCount(accomodation.getReviewList().size())
+                .description(accommodation.getDescription())
+//                .provisionTag(accomodation.getProvisionTags().stream()
+//                        .map(ProvisionTag::getName)
+//                        .collect(Collectors.toList())
+//                )
+                .roomType(room.getRoomType())
+                .bed(room.getBed())
+                .roomImages(room.getRoomImageList().stream()
+                        .map(RoomImage::getImgUrl)
+                        .collect(Collectors.toList()))
+                .discountPrice(discountPrice)
+                .totalPrice(discountPrice * days)
+                .cleanlinessScore(accommodation.getCleanlinessScore())
+                .serviceScore(accommodation.getServiceScore())
+                .locationScore(accommodation.getLocationScore())
+                .build();
+    }
+}
+

--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/repository/AccommodationRepository.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/repository/AccommodationRepository.java
@@ -1,0 +1,15 @@
+package com.efub.agodaclone.accomodation.repository;
+
+import com.efub.agodaclone.accomodation.domain.Accommodation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AccommodationRepository extends JpaRepository<Accommodation, Long> {
+    // 숙소 검색 키워드
+    List<Accommodation> findByLocationContaining(String query);
+
+    // 숙소 id로 조회
+    Optional<Accommodation> findByAccommodationId(Long accommodationId);
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/service/AccommodationService.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/accomodation/service/AccommodationService.java
@@ -1,0 +1,59 @@
+package com.efub.agodaclone.accomodation.service;
+
+import com.efub.agodaclone.accomodation.domain.Accommodation;
+import com.efub.agodaclone.accomodation.dto.request.AccommodationSearchRequestDto;
+import com.efub.agodaclone.room.domain.Room;
+import com.efub.agodaclone.accomodation.dto.response.AccommodationDetailResponseDto;
+import com.efub.agodaclone.accomodation.dto.response.AccommodationSearchListResponseDto;
+import com.efub.agodaclone.accomodation.repository.AccommodationRepository;
+import com.efub.agodaclone.room.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AccommodationService {
+
+    private final AccommodationRepository accommodationRepository;
+    private final RoomRepository roomRepository;
+
+    // 숙소 검색 리스트
+    public AccommodationSearchListResponseDto getAccommodationList(AccommodationSearchRequestDto accommodationSearchRequestDto){
+        List<Accommodation> accommodationList = accommodationRepository.findByLocationContaining(accommodationSearchRequestDto.getQuery());
+        int days = getDays(accommodationSearchRequestDto.getStartDate(), accommodationSearchRequestDto.getEndDate());
+
+        return AccommodationSearchListResponseDto.from(accommodationList, days, this::calculateDiscountPrice);
+    }
+
+    // 숙소 상세 정보 조회
+    public AccommodationDetailResponseDto getDetailedAccommodation(Long accomodationId){
+        Accommodation accommodation = accommodationRepository.findByAccommodationId(accomodationId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 숙소입니다."));
+        Room room = findByAccommodationId(accomodationId);
+        int discountPrice = calculateDiscountPrice(accommodation.getPrice(), accommodation.getDiscountRate());
+
+        return AccommodationDetailResponseDto.from(accommodation, room, discountPrice);
+    }
+
+    // 숙소 id로 객실 조회하는 함수
+    public Room findByAccommodationId(Long accommodationId){
+        return roomRepository.findByAccommodationId(accommodationId)
+                .orElseThrow(()-> new IllegalArgumentException("방이 존재하지 않습니다."));
+    }
+
+    // 숙박하는 일 수 계산하는 함수
+    public int getDays(LocalDate startDate, LocalDate endDate){
+        return (int) ChronoUnit.DAYS.between(startDate, endDate);
+    }
+
+    //
+    private int calculateDiscountPrice(int price, int discountRate) {
+        return (int) (price * (1 - discountRate / 100.0));
+    }
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/room/repository/RoomRepository.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/room/repository/RoomRepository.java
@@ -1,0 +1,11 @@
+package com.efub.agodaclone.room.repository;
+
+import com.efub.agodaclone.room.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+    // 숙소 id로 객실 찾기
+    Optional<Room> findByAccommodationId(Long accommodationId);
+}


### PR DESCRIPTION
## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
- 숙소 검색, 숙소 상세 조회 API 생성

## 🧠 구현 과정에서의 고민
- 숙소 검색 리스트를 반환하는 과정에서 할인율에 따라 각각의 할인 후 금액을 계산해서 반환해야 했었습니다.
`  Accommodation` 엔티티에 그냥 `discountPrice` 필드를 추가할지 아니면 할인율에 따라 서비스단에서 계산을 할지 고민했습니다.


## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요.
- 서비스 단에서 `calculateDiscountPrice`라는 계산 로직을 별도로 정의하고, 이 계산 로직을 DTO 변환 과정에서 함수 포인터(`this::calculateDiscountPrice`) 형태로 전달해 할인된 금액을 `AccommodationSummary`에 동적으로 반영하도록 처리했습니다.

## ⚠️ 참고 사항 및 주의할 점
(아래 부분은 지우고 작성)
- `Review` 데이터를 반환하는 부분은 아직 Review 엔티티가 없어서 주석 처리했습니다. 추후 Review 엔티티 추가 후 정상적으로 작동하는지 재확인하겠습니다.

## 🗯️ 느낀 점 / 다음에 개선하고 싶은 점 (선택)
- 할인율은 바뀌는 정보기 때문에 동적으로 계산해서 각각의 숙소의 할인 후 금액을 리스트로 반환해야 했어서 처음에 어떻게 할지 막막했는데 찾아보니 `BiFunction`을 사용해서 `discountCalculator`에 파라미터로 던진 값을 받아서 `AccommodationSummary.from(accomodation, discountPrice, days); `로 던지고 다시 Summary로 반환받는 방법을 알게돼서 새로웠습니다 ! 혹시 이보다 더 나은 방법이 있다면 찾아보도록 하겠습니다.
