### PR TITLE
[Feat] 회원 탈퇴 시 User와 카카오 Unlink 추가

### DIFF
--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/controller/AuthController.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.efub.agodaclone.user.domain.RefreshToken;
 import com.efub.agodaclone.user.dto.KakaoUserResponseDto;
 import com.efub.agodaclone.user.domain.User;
 import com.efub.agodaclone.user.jwt.JwtProvider;
+import com.efub.agodaclone.user.jwt.TokenUtil;
 import com.efub.agodaclone.user.service.KakaoService;
 import com.efub.agodaclone.user.service.RefreshTokenService;
 import com.efub.agodaclone.user.service.UserService;
@@ -43,15 +44,24 @@ public class AuthController {
 
         refreshTokenService.saveOrUpdate(user.getUserId(), refreshToken, LocalDateTime.now().plusDays(14));
 
+        // 카카오 access token 쿠키에 저장
+        ResponseCookie kakaoCookie = ResponseCookie.from("kakao_token", accessToken)
+                .path("/")
+                .httpOnly(true)
+                .secure(false) // https 배포 시 true
+                .maxAge(60 * 60) // 1시간
+                .sameSite("Lax")
+                .domain("localhost") // 배포 시 변경
+                .build();
 
         // 쿠키로 access_token 설정
         ResponseCookie accessCookie = ResponseCookie.from("access_token", jwt)
                 .path("/")
                 .httpOnly(true) // JS에서 접근 불가능하게
-                .secure(false)   // 지금은 테스트용이라 false로 해둠. 나중에 https에서는 true로!!
+                .secure(false)   // TODO: 지금은 테스트용이라 false로 해둠. 나중에 https에서는 true로!!
                 .maxAge(7 * 24 * 60 * 60)
                 .sameSite("Lax")
-                .domain("localhost") //테스트용. 실제는 배포 url로 바꿔야 됨!
+                .domain("localhost") //TODO: 테스트용. 실제는 배포 url로 바꿔야 됨!
                 .build();
 
         // refresh_token 쿠키 설정
@@ -66,6 +76,7 @@ public class AuthController {
 
         response.setHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, kakaoCookie.toString());
 
         return ResponseEntity.ok().build();
     }
@@ -108,6 +119,13 @@ public class AuthController {
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
 
         Long userId = (Long) request.getAttribute("userId");
+        String accessToken = extractAccessTokenFromHeader(request);
+
+        // 카카오 앱 연결 해제
+        String kakaoAccessToken = TokenUtil.extractKakaoTokenFromCookie(request);
+        System.out.println("🧾 unlink에 사용한 token = " + kakaoAccessToken);
+        kakaoService.unlinkKakao(kakaoAccessToken);
+
         userService.deleteUser(userId);
 
         // access_token 쿠키 제거
@@ -128,8 +146,17 @@ public class AuthController {
                 .sameSite("Lax")
                 .build();
 
+        ResponseCookie kakaoCookie = ResponseCookie.from("kakao_token", "")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+
         response.setHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, kakaoCookie.toString());
 
         return ResponseEntity.noContent().build(); // 204 No Content
     }
@@ -145,13 +172,22 @@ public class AuthController {
         return null;
     }
 
-    //////user service test용. 사용 후 삭제
-    @GetMapping("/user/me")
-    public ResponseEntity<?> getMyInfo() {
-        User user = userService.getCurrentUser();
-
-        return ResponseEntity.ok()
-                .body("현재 유저: " + user.getName() + " (id: " + user.getUserId() + ")");
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
     }
+
+
+//    //////user service test용. 사용 후 삭제
+//    @GetMapping("/user/me")
+//    public ResponseEntity<?> getMyInfo() {
+//        User user = userService.getCurrentUser();
+//
+//        return ResponseEntity.ok()
+//                .body("현재 유저: " + user.getName() + " (id: " + user.getUserId() + ")");
+//    }
 
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtProvider.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtProvider.java
@@ -19,7 +19,7 @@ public class JwtProvider {
     @Value("${jwt.secret-key}")
     private String secretKey;
 
-    private final long expirationMs = 3600000;
+    private final long expirationMs = 7 * 24 * 60 * 60 * 1000; //TODO: 일주일로 설정함. 나중에는 1시간 3600000
 
     public String generateToken(Long userId) {
         return Jwts.builder()

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/TokenUtil.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/TokenUtil.java
@@ -1,0 +1,18 @@
+package com.efub.agodaclone.user.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class TokenUtil {
+
+    public static String extractKakaoTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("kakao_token".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/service/KakaoService.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/service/KakaoService.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @Service
@@ -56,4 +57,27 @@ public class KakaoService {
 
         return response.getBody();
     }
+
+    public void unlinkKakao(String kakaoAccessToken) {
+        if (kakaoAccessToken == null) {
+            System.out.println("kakaoAccessToken is null");
+            return;
+        }
+
+        String url = "https://kapi.kakao.com/v1/user/unlink";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        RestTemplate restTemplate = new RestTemplate();
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+            System.out.println("카카오 unlink 성공: " + response.getBody());
+        } catch (HttpClientErrorException e) {
+            System.out.println("unlink 실패: " + e.getStatusCode() + " / " + e.getResponseBodyAsString());
+        }
+    }
+
 }


### PR DESCRIPTION


## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
(아래 부분은 지우고 작성)
- 회원 탈퇴 시 User와 카카오 Unlink 추가
- 지금까지는 회원 탈퇴를 진행해도 kakao에 user 정보가 남아있어, 새로 회원가입을 하려고 해도 동의 화면으로 넘어가지 않고 바로 token을 발급받는 문제가 있었다. 그래서 회원탈퇴 시 unlink를 통해 아예 kakao와의 연결을 끊음.



## 🔎 테스트 내용
어떤 테스트를 수행했는지 명시해주세요.  

- 회원탈퇴 후 새로 회원가입 시도 시 동의 화면부터 시작한다.


## ⚠️ 어려웠던 점과 해결 과정
막혔던 부분과 어떻게 해결했는지 작성해주세요.
(아래 부분은 지우고 작성)
- 카카오 로그인을 하려면 우리 서버에서 발급한 jwt token이 아닌 처음에 받은 kakao token이 필요한데, 이 정보는 저장하고 있지 않았었기 때문에 unlink가 작동하지 않았다.
- 그래서 kakao에서 발급받은 token을 추가로 cookie에 저장하고, 이 kakao token을 꺼내 사용하는 TokenUtil을 작성하였다.
  

## ⚠️ 참고 사항 및 주의할 점
- 현재 프론트와 연결이 되어 있지 않기 때문에, 브라우저가 자동으로 reissue를 해주지 않아 매번 access token을 새로 발급받아야하는 어려움이 있었습니다.
- test용으로 token의 만기 기한을 일주일로 늘려두었으니, 완성 시에는 다시 1시간으로 변경할 것

