### PR TITLE
[Refactor] 배포용 수정 및 TokenUtil refactoring

### DIFF
--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/config/SecurityConfig.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/config/SecurityConfig.java
@@ -14,9 +14,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
+// Spring Security 설정 담당
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    // 허용 경로
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -31,8 +32,7 @@ public class SecurityConfig {
                         .requestMatchers("/oauth/logout").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .csrf(csrf -> csrf.disable()); // CSRF 비활성화
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/controller/AuthController.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/controller/AuthController.java
@@ -11,10 +11,10 @@ import com.efub.agodaclone.user.service.KakaoService;
 import com.efub.agodaclone.user.service.RefreshTokenService;
 import com.efub.agodaclone.user.service.UserService;
 import com.efub.agodaclone.user.repository.RefreshTokenRepository;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -33,35 +33,39 @@ public class AuthController {
     private final RefreshTokenRepository refreshTokenRepository;
     private final RefreshTokenService refreshTokenService;
 
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    //카카오 로그인
     @GetMapping("/oauth/login")
     public ResponseEntity<?> kakaoCallback(@RequestParam("code") String code, HttpServletResponse response) {
-        String accessToken = kakaoService.getAccessToken(code);
-        KakaoUserResponseDto kakaoUserResponseDto = kakaoService.getUserInfo(accessToken);
-        User user = userService.registerOrLogin(kakaoUserResponseDto);
+        String accessToken = kakaoService.getAccessToken(code); //인가 코드로 access token 발급
+        KakaoUserResponseDto kakaoUserResponseDto = kakaoService.getUserInfo(accessToken); //사용자 정보 조회
+        User user = userService.registerOrLogin(kakaoUserResponseDto); // 사용자 등록
 
-        String jwt = jwtProvider.generateToken(user.getUserId());
-        String refreshToken = jwtProvider.generateRefreshToken(user.getUserId());
+        String jwt = jwtProvider.generateToken(user.getUserId()); //jwt token 생성
+        String refreshToken = jwtProvider.generateRefreshToken(user.getUserId()); //jwt refresh token 생성
 
         refreshTokenService.saveOrUpdate(user.getUserId(), refreshToken, LocalDateTime.now().plusDays(14));
 
-        // 카카오 access token 쿠키에 저장
+        // 카카오 token을 쿠키에 저장
         ResponseCookie kakaoCookie = ResponseCookie.from("kakao_token", accessToken)
                 .path("/")
                 .httpOnly(true)
-                .secure(false) // https 배포 시 true
+                .secure(true) // https 환경 true
                 .maxAge(60 * 60) // 1시간
                 .sameSite("Lax")
-                .domain("localhost") // 배포 시 변경
+                .domain(frontendUrl.replace("https://", "").replace("http://", ""))
                 .build();
 
         // 쿠키로 access_token 설정
         ResponseCookie accessCookie = ResponseCookie.from("access_token", jwt)
                 .path("/")
                 .httpOnly(true) // JS에서 접근 불가능하게
-                .secure(false)   // TODO: 지금은 테스트용이라 false로 해둠. 나중에 https에서는 true로!!
+                .secure(true)   // https 환경 true
                 .maxAge(7 * 24 * 60 * 60)
                 .sameSite("Lax")
-                .domain("localhost") //TODO: 테스트용. 실제는 배포 url로 바꿔야 됨!
+                .domain(frontendUrl.replace("https://", "").replace("http://", ""))
                 .build();
 
         // refresh_token 쿠키 설정
@@ -71,7 +75,7 @@ public class AuthController {
                 .secure(true)
                 .maxAge(14 * 24 * 60 * 60) // 예: 14일
                 .sameSite("Lax")
-                .domain("localhost")
+                .domain(frontendUrl.replace("https://", "").replace("http://", ""))
                 .build();
 
         response.setHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
@@ -81,9 +85,10 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
+    // Access Token 재발급
     @PostMapping("/oauth/reissue")
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        String refreshToken = TokenUtil.extractRefreshTokenFromCookie(request); //쿠키에서 refresh token 추출
 
         // DB에서 refresh token 조회 및 검증
         Optional<RefreshToken> savedToken = refreshTokenRepository.findByToken(refreshToken);
@@ -99,6 +104,7 @@ public class AuthController {
             throw new AgodaException(ExceptionCode.REFRESH_TOKEN_EMPTY);
         }
 
+        // 새 access token 쿠키로 설정
         ResponseCookie accessCookie = ResponseCookie.from("access_token", newAccessToken)
                 .path("/")
                 .httpOnly(true)
@@ -113,19 +119,17 @@ public class AuthController {
 
     }
 
-
-
+    // 로그아웃
     @DeleteMapping("/oauth/logout")
     public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
 
         Long userId = (Long) request.getAttribute("userId");
-        String accessToken = extractAccessTokenFromHeader(request);
 
         // 카카오 앱 연결 해제
         String kakaoAccessToken = TokenUtil.extractKakaoTokenFromCookie(request);
-        System.out.println("🧾 unlink에 사용한 token = " + kakaoAccessToken);
         kakaoService.unlinkKakao(kakaoAccessToken);
 
+        //DB에서 유저 삭제
         userService.deleteUser(userId);
 
         // access_token 쿠키 제거
@@ -146,6 +150,7 @@ public class AuthController {
                 .sameSite("Lax")
                 .build();
 
+        // kakao token 쿠키 제거
         ResponseCookie kakaoCookie = ResponseCookie.from("kakao_token", "")
                 .path("/")
                 .httpOnly(true)
@@ -158,36 +163,7 @@ public class AuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, kakaoCookie.toString());
 
-        return ResponseEntity.noContent().build(); // 204 No Content
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
-
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() == null) return null;
-
-        for (Cookie cookie : request.getCookies()) {
-            if (cookie.getName().equals("refresh_token")) {
-                return cookie.getValue();
-            }
-        }
-        return null;
-    }
-
-    private String extractAccessTokenFromHeader(HttpServletRequest request) {
-        String header = request.getHeader("Authorization");
-        if (header != null && header.startsWith("Bearer ")) {
-            return header.substring(7);
-        }
-        return null;
-    }
-
-
-//    //////user service test용. 사용 후 삭제
-//    @GetMapping("/user/me")
-//    public ResponseEntity<?> getMyInfo() {
-//        User user = userService.getCurrentUser();
-//
-//        return ResponseEntity.ok()
-//                .body("현재 유저: " + user.getName() + " (id: " + user.getUserId() + ")");
-//    }
 
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/domain/CustomUserDetails.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/domain/CustomUserDetails.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 
 @Getter
 public class CustomUserDetails implements UserDetails {
+//Spring Security가 로그인한 사용자의 정보를 처리
+
     private final Long id;
     private final String email;
     private final String name;

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtAuthenticationFilter.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import com.efub.agodaclone.user.domain.User;
 import com.efub.agodaclone.user.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,17 +22,20 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    //Spring Security에서 JWT 인증을 수행
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
+    //모든 요청마다 수행
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String token = extractTokenFromHeaderOrCookie(request);
+        String token = TokenUtil.extractTokenFromHeaderOrCookie(request); //토큰 추출
 
+        // toke 유효성 검사 후 사용자 조회
         if (token != null) {
             Long userId = jwtProvider.validateAndGetUserId(token);
 
@@ -51,20 +53,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String extractTokenFromHeaderOrCookie(HttpServletRequest request) {
-        String header = request.getHeader("Authorization");
-        if (header != null && header.startsWith("Bearer ")) {
-            return header.substring(7);
-        }
 
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if (cookie.getName().equals("access_token")) {
-                    return cookie.getValue();
-                }
-            }
-        }
-
-        return null;
-    }
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtProvider.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/JwtProvider.java
@@ -14,13 +14,14 @@ import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 @Component
-public class JwtProvider {
+public class JwtProvider { //jwt 발급
 
     @Value("${jwt.secret-key}")
     private String secretKey;
 
-    private final long expirationMs = 7 * 24 * 60 * 60 * 1000; //TODO: 일주일로 설정함. 나중에는 1시간 3600000
+    private final long expirationMs = 36000000; //10시간
 
+    //사용자의 id를 받아 access token 발급
     public String generateToken(Long userId) {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
@@ -41,6 +42,7 @@ public class JwtProvider {
                 .compact();
     }
 
+    //jwt 서명 검증
     public Long validateAndGetUserId(String token) {
         Claims claims = Jwts.parser()
                 .setSigningKey(getKey())

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/TokenUtil.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/jwt/TokenUtil.java
@@ -3,8 +3,9 @@ package com.efub.agodaclone.user.jwt;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
+//쿠키에서 값을 추출
 public class TokenUtil {
-
+    // kakao token 값 추출
     public static String extractKakaoTokenFromCookie(HttpServletRequest request) {
         if (request.getCookies() == null) return null;
 
@@ -13,6 +14,36 @@ public class TokenUtil {
                 return cookie.getValue();
             }
         }
+        return null;
+    }
+
+    // 쿠키에서 refresh token 추출
+    public static String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("refresh_token")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    //헤더 또는 쿠키에서 access token 추출
+    public static String extractTokenFromHeaderOrCookie(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie.getName().equals("access_token")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/repository/RefreshTokenRepository.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/repository/RefreshTokenRepository.java
@@ -7,6 +7,5 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
-    Optional<RefreshToken> findByUserId(Long userId);
     void deleteByUserId(Long userId);
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/service/KakaoService.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/service/KakaoService.java
@@ -23,6 +23,7 @@ public class KakaoService {
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
 
+    // 카카오 인가 코드로 access token 발급
     public String getAccessToken(String code) {
         String tokenUrl = "https://kauth.kakao.com/oauth/token";
 
@@ -58,6 +59,7 @@ public class KakaoService {
         return response.getBody();
     }
 
+    //카카오 앱 연결 해체 요청
     public void unlinkKakao(String kakaoAccessToken) {
         if (kakaoAccessToken == null) {
             System.out.println("kakaoAccessToken is null");

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/service/RefreshTokenService.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/service/RefreshTokenService.java
@@ -15,9 +15,10 @@ public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
 
+    // refresh token을 db에 갱신
     @Transactional
     public void saveOrUpdate(Long userId, String token, LocalDateTime expiration) {
-        refreshTokenRepository.deleteByUserId(userId);
+        refreshTokenRepository.deleteByUserId(userId); //기존 토큰 삭제
 
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setUserId(userId);
@@ -27,7 +28,4 @@ public class RefreshTokenService {
         refreshTokenRepository.save(refreshToken);
     }
 
-    public Optional<RefreshToken> findByToken(String token) {
-        return refreshTokenRepository.findByToken(token);
-    }
 }

--- a/agoda-clone/src/main/java/com/efub/agodaclone/user/service/UserService.java
+++ b/agoda-clone/src/main/java/com/efub/agodaclone/user/service/UserService.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
 
+    //사용자 로그인/회원가입
     public User registerOrLogin(KakaoUserResponseDto kakaoUserResponseDto) {
         String kakaoId = String.valueOf(kakaoUserResponseDto.getId());
         Optional<User> userOptional = userRepository.findByKakaoId(kakaoId);
@@ -37,9 +38,10 @@ public class UserService {
         }
     }
 
+    //Security Context에 저장된 사용자 정보로부터 User 엔티티 조회
     @Transactional(readOnly = true)
     public User getCurrentUser() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication(); //인증 객체 가져옴
 
         if (auth == null || !auth.isAuthenticated() || auth.getPrincipal().equals("anonymousUser")) {
             throw new RuntimeException(ClientExceptionCode.UNAUTHORIZED.name());
@@ -54,6 +56,7 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException(ClientExceptionCode.RESOURCE_NOT_FOUND.name()));
     }
 
+    //사용자 삭제
     @Transactional
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)

--- a/agoda-clone/src/main/resources/application.yml
+++ b/agoda-clone/src/main/resources/application.yml
@@ -22,6 +22,7 @@ kakao:
   client-id: ${kakao.client-id}
   redirect-uri: ${kakao.redirect-uri}
   javascript-key: ${kakao.javascript-key}
-
 jwt:
   secret-key: ${jwt.secret-key}
+frontend:
+  url: ${frontend.url}

--- a/hs_err_pid10292.log
+++ b/hs_err_pid10292.log
@@ -1,0 +1,218 @@
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 264241152 bytes for G1 virtual space
+# Possible reasons:
+#   The system is out of physical RAM or swap space
+#   The process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap
+# Possible solutions:
+#   Reduce memory load on the system
+#   Increase physical memory or swap space
+#   Check if swap backing store is full
+#   Decrease Java heap size (-Xmx/-Xms)
+#   Decrease number of Java threads
+#   Decrease Java thread stack sizes (-Xss)
+#   Set larger code cache with -XX:ReservedCodeCacheSize=
+#   JVM is running with Zero Based Compressed Oops mode in which the Java heap is
+#     placed in the first 32GB address space. The Java Heap base address is the
+#     maximum limit for the native heap growth. Please use -XX:HeapBaseMinAddress
+#     to set the Java Heap base and to place the Java Heap above 32GB virtual address.
+# This output file may be truncated or incomplete.
+#
+#  Out of Memory Error (os_windows.cpp:3550), pid=10292, tid=25976
+#
+# JRE version:  (17.0.6+9) (build )
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (17.0.6+9-LTS-190, mixed mode, emulated-client, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, windows-amd64)
+# No core dump will be written. Minidumps are not enabled by default on client versions of Windows
+#
+
+---------------  S U M M A R Y ------------
+
+Command Line: -XX:TieredStopAtLevel=1 -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -Dmanagement.endpoints.jmx.exposure.include=* -javaagent:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\lib\idea_rt.jar=63534:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin -Dfile.encoding=UTF-8 com.efub.agodaclone.AgodaCloneApplication
+
+Host: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz, 8 cores, 15G,  Windows 11 , 64 bit Build 26100 (10.0.26100.3912)
+Time: Fri May 23 22:51:52 2025  Windows 11 , 64 bit Build 26100 (10.0.26100.3912) elapsed time: 0.045244 seconds (0d 0h 0m 0s)
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00000211efe3ac80):  JavaThread "Unknown thread" [_thread_in_vm, id=25976, stack(0x000000ea01b00000,0x000000ea01c00000)]
+
+Stack: [0x000000ea01b00000,0x000000ea01c00000]
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [jvm.dll+0x6734ea]
+V  [jvm.dll+0x7d18f4]
+V  [jvm.dll+0x7d309e]
+V  [jvm.dll+0x7d3703]
+V  [jvm.dll+0x2433c5]
+V  [jvm.dll+0x6703f9]
+V  [jvm.dll+0x664d32]
+V  [jvm.dll+0x300086]
+V  [jvm.dll+0x307606]
+V  [jvm.dll+0x356c1e]
+V  [jvm.dll+0x356e4f]
+V  [jvm.dll+0x2d72e8]
+V  [jvm.dll+0x2d8254]
+V  [jvm.dll+0x7a33b1]
+V  [jvm.dll+0x3647f1]
+V  [jvm.dll+0x782839]
+V  [jvm.dll+0x3e757f]
+V  [jvm.dll+0x3e9001]
+C  [jli.dll+0x5297]
+C  [ucrtbase.dll+0x37b0]
+C  [KERNEL32.DLL+0x2e8d7]
+C  [ntdll.dll+0x9c5dc]
+
+
+---------------  P R O C E S S  ---------------
+
+Threads class SMR info:
+_java_thread_list=0x00007ffa6af3e958, length=0, elements={
+}
+
+Java Threads: ( => current thread )
+
+Other Threads:
+  0x00000211efea7130 GCTaskThread "GC Thread#0" [stack: 0x000000ea01c00000,0x000000ea01d00000] [id=10000]
+  0x00000211efeb7c30 ConcurrentGCThread "G1 Main Marker" [stack: 0x000000ea01d00000,0x000000ea01e00000] [id=23112]
+  0x00000211efeb8640 ConcurrentGCThread "G1 Conc#0" [stack: 0x000000ea01e00000,0x000000ea01f00000] [id=23776]
+
+[error occurred during error reporting (printing all threads), id 0xc0000005, EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x00007ffa6a777f07]
+
+VM state: not at safepoint (not fully initialized)
+
+VM Mutex/Monitor currently owned by a thread:  ([mutex/lock_event])
+[0x00000211efe365a0] Heap_lock - owner thread: 0x00000211efe3ac80
+
+Heap address: 0x0000000704400000, size: 4028 MB, Compressed Oops mode: Zero based, Oop shift amount: 3
+
+CDS archive(s) mapped at: [0x0000000000000000-0x0000000000000000-0x0000000000000000), size 0, SharedBaseAddress: 0x0000000800000000, ArchiveRelocationMode: 0.
+Narrow klass base: 0x0000000000000000, Narrow klass shift: 0, Narrow klass range: 0x0
+
+GC Precious Log:
+<Empty>
+
+Heap:
+ garbage-first heap   total 0K, used 0K [0x0000000704400000, 0x0000000800000000)
+  region size 2048K, 0 young (0K), 0 survivors (0K)
+
+[error occurred during error reporting (printing heap information), id 0xc0000005, EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x00007ffa6ab5c759]
+
+GC Heap History (0 events):
+No events
+
+Deoptimization events (0 events):
+No events
+
+Classes unloaded (0 events):
+No events
+
+Classes redefined (0 events):
+No events
+
+Internal exceptions (0 events):
+No events
+
+VM Operations (0 events):
+No events
+
+Events (1 events):
+Event: 0.034 Loaded shared library C:\Program Files\Java\jdk-17\bin\java.dll
+
+
+Dynamic libraries:
+0x00007ff65bee0000 - 0x00007ff65bef0000 	C:\Program Files\Java\jdk-17\bin\java.exe
+0x00007ffac51a0000 - 0x00007ffac5406000 	C:\WINDOWS\SYSTEM32\ntdll.dll
+0x00007ffac4720000 - 0x00007ffac47e9000 	C:\WINDOWS\System32\KERNEL32.DLL
+0x00007ffac2b90000 - 0x00007ffac2f5c000 	C:\WINDOWS\System32\KERNELBASE.dll
+0x00007ffac2800000 - 0x00007ffac294b000 	C:\WINDOWS\System32\ucrtbase.dll
+0x00007ffab7f20000 - 0x00007ffab7f3b000 	C:\Program Files\Java\jdk-17\bin\VCRUNTIME140.dll
+0x00007ffab8890000 - 0x00007ffab88a8000 	C:\Program Files\Java\jdk-17\bin\jli.dll
+0x00007ffac47f0000 - 0x00007ffac48a2000 	C:\WINDOWS\System32\ADVAPI32.dll
+0x00007ffac5080000 - 0x00007ffac5129000 	C:\WINDOWS\System32\msvcrt.dll
+0x00007ffac4ee0000 - 0x00007ffac4f86000 	C:\WINDOWS\System32\sechost.dll
+0x00007ffac4400000 - 0x00007ffac4516000 	C:\WINDOWS\System32\RPCRT4.dll
+0x00007ffac3560000 - 0x00007ffac372a000 	C:\WINDOWS\System32\USER32.dll
+0x00007ffac24b0000 - 0x00007ffac24d7000 	C:\WINDOWS\System32\win32u.dll
+0x00007ffac48b0000 - 0x00007ffac48db000 	C:\WINDOWS\System32\GDI32.dll
+0x00007ffac2610000 - 0x00007ffac2742000 	C:\WINDOWS\System32\gdi32full.dll
+0x00007ffac2750000 - 0x00007ffac27f3000 	C:\WINDOWS\System32\msvcp_win.dll
+0x00007ffab4130000 - 0x00007ffab43ca000 	C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.3912_none_3e07963ce335137e\COMCTL32.dll
+0x00007ffab9210000 - 0x00007ffab921b000 	C:\WINDOWS\SYSTEM32\VERSION.dll
+0x00007ffac5040000 - 0x00007ffac5070000 	C:\WINDOWS\System32\IMM32.DLL
+0x00007ffabcb30000 - 0x00007ffabcb3c000 	C:\Program Files\Java\jdk-17\bin\vcruntime140_1.dll
+0x00007ffaa6cc0000 - 0x00007ffaa6d4e000 	C:\Program Files\Java\jdk-17\bin\msvcp140.dll
+0x00007ffa6a490000 - 0x00007ffa6b067000 	C:\Program Files\Java\jdk-17\bin\server\jvm.dll
+0x00007ffac4c70000 - 0x00007ffac4c78000 	C:\WINDOWS\System32\PSAPI.DLL
+0x00007ffabec10000 - 0x00007ffabec46000 	C:\WINDOWS\SYSTEM32\WINMM.dll
+0x00007ffabbf10000 - 0x00007ffabbf1a000 	C:\WINDOWS\SYSTEM32\WSOCK32.dll
+0x00007ffac4e60000 - 0x00007ffac4ed4000 	C:\WINDOWS\System32\WS2_32.dll
+0x00007ffac10f0000 - 0x00007ffac110a000 	C:\WINDOWS\SYSTEM32\kernel.appcore.dll
+0x00007ffabc9f0000 - 0x00007ffabc9fa000 	C:\Program Files\Java\jdk-17\bin\jimage.dll
+0x00007ffabfac0000 - 0x00007ffabfd01000 	C:\WINDOWS\SYSTEM32\DBGHELP.DLL
+0x00007ffac48e0000 - 0x00007ffac4c64000 	C:\WINDOWS\System32\combase.dll
+0x00007ffac3320000 - 0x00007ffac3400000 	C:\WINDOWS\System32\OLEAUT32.dll
+0x00007ffabebd0000 - 0x00007ffabec09000 	C:\WINDOWS\SYSTEM32\dbgcore.DLL
+0x00007ffac2570000 - 0x00007ffac2609000 	C:\WINDOWS\System32\bcryptPrimitives.dll
+0x00007ffabc930000 - 0x00007ffabc93e000 	C:\Program Files\Java\jdk-17\bin\instrument.dll
+0x00007ffaac670000 - 0x00007ffaac695000 	C:\Program Files\Java\jdk-17\bin\java.dll
+
+dbghelp: loaded successfully - version: 4.0.5 - missing functions: none
+symbol engine: initialized successfully - sym options: 0x614 - pdb path: .;C:\Program Files\Java\jdk-17\bin;C:\WINDOWS\SYSTEM32;C:\WINDOWS\WinSxS\amd64_microsoft.windows.common-controls_6595b64144ccf1df_6.0.26100.3912_none_3e07963ce335137e;C:\Program Files\Java\jdk-17\bin\server
+
+VM Arguments:
+jvm_args: -XX:TieredStopAtLevel=1 -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -Dmanagement.endpoints.jmx.exposure.include=* -javaagent:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\lib\idea_rt.jar=63534:C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin -Dfile.encoding=UTF-8 
+java_command: com.efub.agodaclone.AgodaCloneApplication
+java_class_path (initial): C:\Users\yookr\agoda-clone-be\agoda-clone\build\classes\java\main;C:\Users\yookr\agoda-clone-be\agoda-clone\build\resources\main;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.projectlombok\lombok\1.18.38\57f8f5e02e92a30fd21b80cbd426a4172b5f8e29\lombok-1.18.38.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-data-jpa\3.4.5\c6ef06dfef1b02f3e3f82d67118d3944672e7d49\spring-boot-starter-data-jpa-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-oauth2-client\3.4.5\694947a954ed9f25873f5f391cb91a30bb933522\spring-boot-starter-oauth2-client-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-security\3.4.5\1893f9d40f28cc47a87a3478b02e1e45650bfe43\spring-boot-starter-security-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-web\3.4.5\54cb03e8615f0c10cd44b5b7d155af3d0be7d66a\spring-boot-starter-web-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-validation\3.4.5\ac75735317fbb71d00829559d1a0a21978989f0\spring-boot-starter-validation-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\io.jsonwebtoken\jjwt-api\0.11.5\f742940045619d06383e7df37b21ac422b476cf1\jjwt-api-0.11.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter-jdbc\3.4.5\e361f635454d0694547cc226ece3aa10fde7ff2b\spring-boot-starter-jdbc-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.boot\spring-boot-starter\3.4.5\3b1cd30bd3be52f5fd0c0934882ec86ed4457646\spring-boot-starter-3.4.5.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.hibernate.orm\hibernate-core\6.6.13.Final\e7f1b2d53e89b9863dca12cd5f1b261ba413415b\hibernate-core-6.6.13.Final.jar;C:\Users\yookr\.gradle\caches\modules-2\files-2.1\org.springframework.data\sprin
+Launcher Type: SUN_STANDARD
+
+[Global flags]
+     intx CICompilerCount                          = 4                                         {product} {ergonomic}
+     uint ConcGCThreads                            = 2                                         {product} {ergonomic}
+     uint G1ConcRefinementThreads                  = 8                                         {product} {ergonomic}
+   size_t G1HeapRegionSize                         = 2097152                                   {product} {ergonomic}
+    uintx GCDrainStackTargetSize                   = 64                                        {product} {ergonomic}
+   size_t InitialHeapSize                          = 264241152                                 {product} {ergonomic}
+     bool ManagementServer                         = true                                      {product} {command line}
+   size_t MarkStackSize                            = 4194304                                   {product} {ergonomic}
+   size_t MaxHeapSize                              = 4223664128                                {product} {ergonomic}
+   size_t MinHeapDeltaBytes                        = 2097152                                   {product} {ergonomic}
+   size_t MinHeapSize                              = 8388608                                   {product} {ergonomic}
+    uintx NonProfiledCodeHeapSize                  = 0                                      {pd product} {ergonomic}
+     bool ProfileInterpreter                       = false                                  {pd product} {command line}
+    uintx ProfiledCodeHeapSize                     = 0                                      {pd product} {ergonomic}
+   size_t SoftMaxHeapSize                          = 4223664128                             {manageable} {ergonomic}
+     intx TieredStopAtLevel                        = 1                                         {product} {command line}
+     bool UseCompressedClassPointers               = true                           {product lp64_product} {ergonomic}
+     bool UseCompressedOops                        = true                           {product lp64_product} {ergonomic}
+     bool UseG1GC                                  = true                                      {product} {ergonomic}
+     bool UseLargePagesIndividualAllocation        = false                                  {pd product} {ergonomic}
+
+Logging:
+Log output configuration:
+ #0: stdout all=warning uptime,level,tags
+ #1: stderr all=off uptime,level,tags
+
+Environment Variables:
+JAVA_HOME=C:\Program Files\Java\jdk1.8.0_231
+PATH=C:\Program Files\MongoDB\Server\8.0\bin;C:\Python313\;C:\Program Files (x86)\VMware\VMware Workstation\bin\;C:\Program Files\Common Files\Oracle\Java\javapath;C:\ProgramData\Miniconda3;C:\ProgramData\Miniconda3\Library\mingw-w64\bin;C:\ProgramData\Miniconda3\Library\usr\bin;C:\ProgramData\Miniconda3\Library\bin;C:\ProgramData\Miniconda3\Scripts;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;c:\Program Files (x86)\Microsoft SQL Server\100\Tools\Binn\;c:\Program Files\Microsoft SQL Server\100\Tools\Binn\;c:\Program Files\Microsoft SQL Server\100\DTS\Binn\;C:\Program Files\Java\jdk1.8.0_231;C:\Program Files\Java\jdk1.8.0_231lib;C:\Program Files\Java\jdk-15.0.2\bin;C:\Program Files\Git\cmd;C:\Program Files\Java\jdk1.8.0_231\bin;C:\Program Files\PuTTY\;C:\Program Files\nodejs\;C:\ProgramData\chocolatey\bin;C:\Scoop\apps\vscode\current\bin;C:\Scoop\apps\nodejs-lts\current\bin;C:\Scoop\apps\nodejs-lts\current;C:\Scoop\shims;C:\Users\yookr\AppData\Local\Programs\Python\Python311\Scripts\;C:\Users\yookr\AppData\Local\Programs\Python\Python311\;C:\Users\yookr\AppData\Local\Microsoft\WindowsApps;C:\Users\yookr\AppData\Local\Programs\Microsoft VS Code\bin;C:\Program Files\JetBrains\PyCharm Community Edition 2023.2.1\bin;C:\Users\yookr\AppData\Local\GitHubDesktop\bin;C:\Program Files\JetBrains\IntelliJ IDEA 2024.1.1\bin;;C:\Users\yookr\AppData\Local\Microsoft\WindowsApps;C:\Users\yookr\AppData\Roaming\npm
+USERNAME=yookr
+OS=Windows_NT
+PROCESSOR_IDENTIFIER=Intel64 Family 6 Model 140 Stepping 1, GenuineIntel
+
+
+
+---------------  S Y S T E M  ---------------
+
+OS:
+ Windows 11 , 64 bit Build 26100 (10.0.26100.3912)
+OS uptime: 8 days 5:42 hours
+
+CPU: total 8 (initial active 8) (4 cores per cpu, 2 threads per core) family 6 model 140 stepping 1 microcode 0x9a, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, avx512f, avx512dq, avx512cd, avx512bw, avx512vl, sha, fma, vzeroupper, avx512_vpopcntdq, avx512_vpclmulqdq, avx512_vaes, avx512_vnni, clflush, clflushopt, clwb, avx512_vbmi2, avx512_vbmi
+
+Memory: 4k page, system-wide physical 16108M (2007M free)
+TotalPageFile size 32412M (AvailPageFile size 154M)
+current process WorkingSet (physical memory assigned to process): 12M, peak: 12M
+current process commit charge ("private bytes"): 55M, peak: 307M
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (17.0.6+9-LTS-190) for windows-amd64 JRE (17.0.6+9-LTS-190), built on Dec  6 2022 15:53:54 by "mach5one" with MS VC++ 17.1 (VS2022)
+
+END.


### PR DESCRIPTION

## ✅ 요약
해당 PR에서 어떤 작업을 했는지 요약해주세요.
- 배포용 수정
  - access Token 만료 기한 1주일 -> 10시간으로 변경
  - 기존의 localhost 대신 frontend.url로 yml 환경변수 설정
  - 쿠키 설정 `.secure(true)`로 https 경로만 허용
- TokenUtil refactoring
  - AuthController에서 사용하는 `extractRefreshTokenFromCookie()`, `extractAccessTokenFromHeader()`함수 TokenUtil로 이동
  - JwtAuthenticationFilter에서 사용하는 `extractTokenFromHeaderOrCookie`함수 TokenUtil로 이동
- 주석 및 설명 추가
- 사용하지 않는 변수, 함수 삭제


## ⚠️ 참고 사항 및 주의할 점
- 배포용으로 수정되었습니다.
- secure 관련 설정이 바뀌었기 때문에 로컬에서 테스트 불가합니다.
- frontend.url 환경변수 설정 필요(.yml)

